### PR TITLE
Production ready website image

### DIFF
--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -7,8 +7,7 @@ services:
   website:
     build: "services/website"
     ports:
-      - "3000:3000" # expose webserver to host machine
-    tty: true # create-react-app dev server terminal magic
+      - "3000:5000" # expose webserver to host machine
     volumes:
       - "./services/website/SnapShot/src:/SnapShot/src"
     environment:

--- a/services/website/Dockerfile
+++ b/services/website/Dockerfile
@@ -1,9 +1,9 @@
 # https://hub.docker.com/_/node
 FROM node:latest
 
-# TODO: create and serve the optimized build
-
+RUN yarn global add serve
 COPY ./SnapShot /SnapShot
 WORKDIR /SnapShot
 RUN yarn install
-CMD yarn start
+RUN yarn build
+CMD serve -s -n ./build

--- a/services/website/Dockerfile
+++ b/services/website/Dockerfile
@@ -1,10 +1,11 @@
 # https://hub.docker.com/_/node
 FROM node:latest
 
+RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
+WORKDIR /home/node/app
 RUN yarn global add serve
-RUN mkdir -p /website
-WORKDIR /website
-COPY ./SnapShot/package.json ./SnapShot/yarn.lock ./
+USER node
+COPY --chown=node:node ./SnapShot/package.json ./SnapShot/yarn.lock ./
 RUN yarn install
-COPY ./SnapShot .
+COPY --chown=node:node ./SnapShot .
 CMD yarn build && serve -s -n ./build

--- a/services/website/Dockerfile
+++ b/services/website/Dockerfile
@@ -7,5 +7,4 @@ WORKDIR /website
 COPY ./SnapShot/package.json ./SnapShot/yarn.lock ./
 RUN yarn install
 COPY ./SnapShot .
-RUN yarn build
-CMD serve -s -n ./build
+CMD yarn build && serve -s -n ./build

--- a/services/website/Dockerfile
+++ b/services/website/Dockerfile
@@ -2,8 +2,10 @@
 FROM node:latest
 
 RUN yarn global add serve
-COPY ./SnapShot /SnapShot
-WORKDIR /SnapShot
+RUN mkdir -p /website
+WORKDIR /website
+COPY ./SnapShot/package.json ./SnapShot/yarn.lock ./
 RUN yarn install
+COPY ./SnapShot .
 RUN yarn build
 CMD serve -s -n ./build


### PR DESCRIPTION
Resolves #7 

In order to support CRA nuances, the `website` image will perform the "build" (generating optimized assets) as part of the container startup. CRA requires configuration to be resolved at build-time, and this is the best compromise I could come up with.

I considered writing a script to inject configuration at runtime, but maintaining that solution is probably not worth it. In any situation where we need really lean container startup times, we can create derivative images with fixed configs and completed builds.